### PR TITLE
build(snap): update to kuiper 1.0.1

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -49,10 +49,36 @@ done
 # create kuiper directories in $SNAP_DATA
 if [ ! -f "$SNAP_DATA/kuiper/data" ]; then
     mkdir -p "$SNAP_DATA/kuiper/data"
+    mkdir -p "$SNAP_DATA/kuiper/etc/functions"
+    mkdir -p "$SNAP_DATA/kuiper/etc/multilingual"
+    mkdir -p "$SNAP_DATA/kuiper/etc/sinks"
     mkdir -p "$SNAP_DATA/kuiper/etc/sources"
+    mkdir -p "$SNAP_DATA/kuiper/plugins/functions"
+    mkdir -p "$SNAP_DATA/kuiper/plugins/sinks"
+    mkdir -p "$SNAP_DATA/kuiper/plugins/sources"
 
-    cp "$SNAP/etc/"*.yaml "$SNAP_DATA/kuiper/etc"
-    cp "$SNAP/etc/sources/"*.yaml "$SNAP_DATA/kuiper/etc/sources"
+    for cfg in client kuiper; do
+        cp "$SNAP/etc/$cfg.yaml" "$SNAP_DATA/kuiper/etc"
+    done
+
+    # Only include the plugin metadata file for mqtt_source,
+    # as EdgeX currently doesn't provide a default MQTT broker.
+    # Even if it did, configuration (including security) would
+    # need to be provided by configuration file (!compliant).
+    cp "$SNAP/etc/mqtt_source.json" "$SNAP_DATA/kuiper/etc"
+
+    cp "$SNAP/etc/functions/"*.json "$SNAP_DATA/kuiper/etc/functions"
+
+    for sink in file edgex influx log nop; do
+        cp "$SNAP/etc/sinks/$sink.json" "$SNAP_DATA/kuiper/etc/sinks"
+    done
+
+    for src in edgex random; do
+        cp "$SNAP/etc/sources/$src.json" "$SNAP_DATA/kuiper/etc/sources"
+        cp "$SNAP/etc/sources/$src.yaml" "$SNAP_DATA/kuiper/etc/sources"
+    done
+
+    cp "$SNAP/etc/multilingual/"*.ini "$SNAP_DATA/kuiper/etc/multilingual"
 fi
 
 # for the kong pki setup file, we need to set the hostname as localhost

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -393,22 +393,14 @@ apps:
     plugs: [home, removable-media, network]
   kuiper:
     adapter: full
-    command: bin/kuiper-server
+    command: bin/kuiperd
     daemon: simple
     environment:
       KuiperBaseKey: $SNAP_DATA/kuiper
-      # KUIPER_DEBUG: "true"
-      KUIPER_CONSOLE_LOG: "true"
-      KUIPER_REST_PORT: 48075
-      EDGEX_SERVER: localhost
-      EDGEX_SERVICE_SERVER: http://localhost:48080
-      EDGEX_TOPIC: events
-      EDGEX_PROTOCOL: tcp
-      EDGEX_PORT: 5566
     plugs: [network, network-bind]
   kuiper-cli:
     adapter: full
-    command: bin/kuiper-cli
+    command: bin/kuiper
     environment:
       KuiperBaseKey: $SNAP_DATA/kuiper
     plugs: [home, network, network-bind]
@@ -789,7 +781,7 @@ parts:
 
   kuiper:
     source: https://github.com/emqx/kuiper.git
-    source-tag: 0.4.1
+    source-tag: 1.0.1
     plugin: make
     after: [go115]
     override-build: |
@@ -801,14 +793,28 @@ parts:
       make build_with_edgex
       make real_pkg
       cd $SNAPCRAFT_PART_INSTALL
+      # TODO: SIMPLIFY THIS!!!
       tar -xvf kuiper*.tar.gz --strip-components=1
       rm *.zip *.gz
 
+      # configure logging
+      sed -i -e 's@consoleLog\: false@consoleLog\: true@' \
+        -e 's@fileLog\: true@fileLog\: false@' \
+        $SNAPCRAFT_PART_INSTALL/etc/kuiper.yaml
+
+      # update the edgex source's port to 5566 to match
+      # app-service-configurable's message bus publish port
+      sed -i -e 's@port\: 5563@port\: 5566@' \
+        $SNAPCRAFT_PART_INSTALL/etc/sources/edgex.yaml
+
+      # update the edgex sink's port to 5567 so that it
+      # doesn't collide with the default port used by
+      # app-service-configurable
+      sed -i -e 's@"default": 5563@"default": 5567@' \
+        $SNAPCRAFT_PART_INSTALL/etc/sinks/edgex.json
+
       install -DT "$SNAPCRAFT_PART_SRC/LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/kuiper/LICENSE"
-    organize:
-      bin/cli: bin/kuiper-cli
-      bin/server: bin/kuiper-server
     stage:
       - -etc/mqtt_source.yaml
     stage-packages:


### PR DESCRIPTION
This change updates the version of the Kuiper rules-engine from 0.4.2 to 1.0.1.

In addition to changing the version of Kuiper, the following changes were made to Kuiper configuration files:

 -` /etc/kuiper.yaml`: edits to the service configuration to disable file-based logging
 - `/etc/sources/edgex.yaml`: msg bus port is set to 5566 to match app-service-configurable
 - `/etc/sinks/edgex.json`: msg bus port is set to 5567 so as to no collide with core-data

## Other information
This PR has been testing by enabling Kuiper in the snap:

`$ sudo snap set edgexfoundry kuiper=on
`
...and then verifying that both Kuiper and app-service-configurable are running via:

`$ sudo snap services edgexfoundry
`
In addition, I also ran the basic rules engine scenario as described in the [Kuiper EdgeX tutorial documentation](https://github.com/emqx/kuiper/blob/master/docs/en_US/edgex/edgex_rule_engine_tutorial.md) and verified that the analysis results are properly exported to emq's MQTT broker.

## install mosquitto

`$ sudo snap install mosquitto
`
## create an kuiper stream

`$ edgexfoundry.kuiper-cli create stream demo'() WITH (FORMAT="JSON", TYPE="edgex")'
`

## create a rule
First copy the following JSON to a file named rule1.txt:

```
{
  "sql": "SELECT * from demo",
  "actions": [
    {
      "mqtt": {
        "server": "tcp://broker.emqx.io:1883",
        "topic": "result",
        "clientId": "demo_001"
      }
    },
    {
      "log":{}
    }
  ]
}
```
..then create the rule with this command:

`$ edgexfoundry.edgex-cli create rule rule1 -f rule.txt
`
## activate device-virtual

`$ sudo snap set edgexfoundry device-virtual=on
`
## monitor emq's broker for analytics events

`$ mosquitto_sub -h broker.emqx.io -t result`