### PR TITLE
Rich configure hook

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -109,9 +109,6 @@ ALL_SERVICES="$ALL_SERVICES sys-mgmt-agent"
 # kuiper
 ALL_SERVICES="$ALL_SERVICES kuiper"
 
-# services that use the database
-DB_SERVICES=(core-command core-data core-metadata support-notifications support-scheduler)
-
 # handle_svc will either turn a service off or on and set the associated
 # config item
 # first arg is the service, second is the state to put it in
@@ -132,28 +129,6 @@ handle_svc () {
         echo "invalid setting $2 for service $1"
         exit 1;;
     esac
-}
-
-restart_db_services () {
-    # since the configuration files have been modified, those
-    # changes need to be progpogated into relevant services, so
-    # restart the services with updated configuration if they were
-    # already running
-    for svc in ${DB_SERVICES[*]}; do
-        status=`snapctl services "$SNAP_NAME.$svc" | grep -o "^active"`
-
-        if [ "$status" = "active" ]; then
-            snapctl restart "$SNAP_NAME.$svc"
-        fi
-    done
-}
-
-update_consul_db_type () {
-    curl -s --request PUT --data "$2" \
-        http://localhost:8500/v1/kv/edgex/core/1.0/edgex-"$1"/Databases/Primary/Type
-
-    curl -s --request PUT --data "$3" \
-        http://localhost:8500/v1/kv/edgex/core/1.0/edgex-"$1"/Databases/Primary/Port
 }
 
 handle_config () {
@@ -303,15 +278,3 @@ for key in $ALL_SERVICES; do
     esac
 done
 
-# handle usage of database provider
-#
-# FIXME (HANOI)
-#
-# The code to switch dbtype has been removed, however
-# I'm leaving the snapctl get to retrive the dbtype, as
-# this may be leveraged in the configure hook of Hanio
-# to block refresh from Geneva to Hanoi if the dbtype
-# is set to 'mongodb' and the project has not yet provided
-# a database migration script...
-dbProvider=$(snapctl get dbtype)
-PREV_DB_PROVIDER_FILE="$SNAP_DATA/prevdbtype"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,5 +1,81 @@
 #!/bin/bash
 
+logger "edgexfoundry CONFIGURE hook START"
+
+# TODO: source from another file???
+declare -A conf_to_env
+
+# [Writable] - not yet supported
+# conf_to_env["writable.log-level"]="BootTimeout"
+
+# [Service]
+conf_to_env["service.boot-timeout"]="SERVICE_BOOTTIMEOUT"
+conf_to_env["service.check-interval"]="SERVICE_CHECKINTERVAL"
+conf_to_env["service.host"]="SERVICE_HOST"
+conf_to_env["service.server-bind-addr"]="SERVICE_SERVERBINDADDR"
+conf_to_env["service.port"]="SERVICE_PORT"
+conf_to_env["service.protocol"]="SERVICE_PROTOCOL"
+conf_to_env["service.max-result-count"]="SERVICE_MAXRESULTCOUNT"
+conf_to_env["service.startup-msg"]="SERVICE_STARTUPMSG"
+conf_to_env["service.timeout"]="SERVICE_TIMEOUT"
+
+# [Registry]
+conf_to_env["registry.host"]="REGISTRY_HOST"
+conf_to_env["registry.port"]="REGISTRY_PORT"
+conf_to_env["registry.type"]="REGISTRY_TYPE"
+
+# [Clients.Metadata]
+conf_to_env["clients.metadata.host"]="CLIENTS_METADATA_HOST"
+conf_to_env["clients.metadata.port"]="CLIENTS_METADATA_PORT"
+conf_to_env["clients.metadata.protocol"]="CLIENTS_METADATA_PROTOCOL"
+
+# [Clients.Notifications] -- restriced to core-metata, scheduler, and SMA?
+conf_to_env["clients.notifications.host"]="CLIENTS_METADATA_HOST"
+conf_to_env["clients.notifications.port"]="CLIENTS_METADATA_PORT"
+conf_to_env["clients.notifications.protocol"]="CLIENTS_METADATA_PROTOCOL"
+# [Databases]
+conf_to_env["databases.primary.host"]="DATABASES_PRIMARY_HOST"
+conf_to_env["databases.primary.name"]="DATABASES_PRIMARY_NAME"
+conf_to_env["databases.primary.password"]="DATABASES_PRIMARY_PASSWORD"
+conf_to_env["databases.primary.username"]="DATABASES_PRIMARY_USERNAME"
+conf_to_env["databases.primary.port"]="DATABASES_PRIMARY_PORT"
+conf_to_env["databases.primary.timeout"]="DATABASES_PRIMARY_TIMEOUT"
+conf_to_env["databases.primary.type"]="DATABASES_PRIMARY_TYPE"
+# [MessageQueue]
+#conf_to_env["messagequeue.protocol"]="MESSAGEQUEUE_PROTOCOL"
+#conf_to_env["messagequeue.host"]="MESSAGEQUEUE_HOST"
+#conf_to_env["messagequeue.port"]="MESSAGEQUEUE_PORT"
+#conf_to_env["messagequeue.type"]="MESSAGEQUEUE_TYPE"
+conf_to_env["messagequeue.topic"]="MESSAGEQUEUE_TOPIC"
+# [MessageQueue.Optional] - not yet supported
+# [SecretStore]
+conf_to_env["secretstore.host"]="SECRETSTORE_HOST"
+conf_to_env["secretstore.port"]="SECRETSTORE_PORT"
+conf_to_env["secretstore.path"]="SECRETSTORE_PATH"
+conf_to_env["secretstore.protocol"]="SECRETSTORE_PROTOCOL"
+conf_to_env["secretstore.root-ca-cert-path"]="SECRETSTORE_ROOTCACERTPATH"
+conf_to_env["secretstore.server-name"]="SECRETSTORE_SERVERNAME"
+conf_to_env["secretstore.token-file"]="SECRETSTORE_TOKENFILE"
+conf_to_env["secretstore.additional-retry-attempts"]="SECRETSTORE_ADDITIONALRETRYATTEMPTS"
+conf_to_env["secretstore.retry-wait-period"]="SECRETSTORE_RETRYWAITPERIOD"
+# [SecretStore.Authentication]
+conf_to_env["secretstore.authentication.auth-type"]="SECRETSTORE_AUTHENTICATION_AUTHTYPE"
+# support-notifications options
+# [Smtp]
+conf_to_env["smtp.host"]="SMTP_HOST"
+conf_to_env["smtp.username"]="SMTP_USERNAME"
+conf_to_env["smtp.password"]="SMTP_PASSWORD"
+conf_to_env["smtp.port"]="SMTP_PORT"
+conf_to_env["smtp.sender"]="SMTP_SENDER"
+conf_to_env["smtp.enable-self-signed-cert"]="SMTP_ENABLE_SELF_SIGNED_CERT"
+
+# The syntax to set a configuration key is:
+#
+# env.<service name>.<section>.<keyname>
+# 
+# This initial implementation only supports EdgeX core-* and
+# support-* services.
+
 # this is a little hackish, but reads better to use string concatenation 
 # to build the list of services than have a long string 
 ALL_SERVICES=""
@@ -80,9 +156,81 @@ update_consul_db_type () {
         http://localhost:8500/v1/kv/edgex/core/1.0/edgex-"$1"/Databases/Primary/Port
 }
 
+handle_config () {
+    # the following logic to convert a JSON key/value array to a bash map is
+    # based on the following stackoverflow example:
+    #
+    # https://stackoverflow.com/questions/26717277/converting-a-json-object-into-a-bash-associative-array
+    #
+    # FIXME: one issue with this implementation is that it strips quotes that may have been specified
+    # when 'snap set' was called. This could cause problems with values that contain spaces or other
+    # special characters.
+
+    map_init=$(echo $2 | jq -r '. as $in | reduce leaf_paths as $path ({}; . + { ($path | map(tostring) | join(".")): $in | getpath($path) }) | to_entries | map("[\(.key)]=\(.value)") | reduce .[] as $item ("configMap=("; . + ($item|@text) + " ") + ")"')
+
+    logger "edgex:configure: $map_init"
+
+    local mapAsString
+    mapAsString="$map_init"
+    local -A "$mapAsString"
+    file="$SNAP_DATA/config/$1/res/$1.env"
+
+    # if no $service.env file exists, create it
+    # TODO: get rid of fore loop, and just access
+    # the first (and only) element in the array
+    if [ ! -f "$file" ]; then
+	logger "edgex:configure: $file NOT FOUND!"
+        for ckey in "${!configMap[@]}"; do
+            val="${configMap["$ckey"]}"
+	    env="${conf_to_env["$ckey"]}"
+
+            # TODO: consider validation of $service & $ckey cominations
+	    # Ex. specifying client.support-scheduler for core-data
+
+            logger "edgex:configure: writing $env=$val to $file"
+            echo "export $env=$val" > "$file"
+            break
+        done
+    else
+        logger "edgex:configure: $file already exists"
+        for key in "${!configMap[@]}"; do
+            val="${configMap["$key"]}"
+	    env="${conf_to_env["$key"]}"
+
+            # TODO: consider validation of $service & $ckey cominations
+	    # Ex. specifying client.support-scheduler for core-data
+
+            found=$(grep "$env" "$file")
+	    if [ -z "$found" ]; then
+		echo "export $env=$val" >> "$file"
+	    else
+                # The following expression uses a negative
+		# address expression to skip updating the line if
+		# matches the existing snapd value
+		sed -i -e "/export $env=$val/! s@$env=.*@$env=$val@" "$file"
+	    fi
+        done
+    fi
+}
+
 for key in $ALL_SERVICES; do
     # get the config key for the service
     status=$(snapctl get "$key")
+    config=$(snapctl get "env.$key")
+
+    if [ ! -z "$config" ]; then
+        handle_config "$key" "$config"
+    fi
+
+    # TODO: most config key changes other than writable.* require service restarts...
+
+    # Does service already have a ENV_OVERRIDES file on disk in $SNAP_DATA/config/<svc>/res?
+    # If so, iterate over config keys in $config; for each
+    #   - lookup environment override name in conf_to_env map
+    #   - is ENV var set in ENV_OVERRIDES already? If yes, is the value the same?
+    #   - if different --> update ENV_OVERRIDES
+    #   - else continue
+    
     case $key in 
         device*)
             # the device services are all using the device-sdk-go which waits

--- a/snap/local/runtime-helpers/bin/service-config-overrides.sh
+++ b/snap/local/runtime-helpers/bin/service-config-overrides.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# convert cmdline to string array
+ARGV=($@)
+
+# grab binary path
+BINPATH="${ARGV[0]}"
+logger "edgex service override: BINPATH=$BINPATH"
+
+# binary name == service name/key
+SERVICE=$(basename "$BINPATH")
+logger "edgex service override: SERVICE=$SERVICE"
+
+SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+logger "edgex service override: : SERVICE_ENV=$SERVICE_ENV"
+
+if [ -f "$SERVICE_ENV" ]; then
+    logger "edgex service override: : sourcing $SERVICE_ENV"
+    source "$SERVICE_ENV"
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -220,6 +220,7 @@ apps:
     command: bin/core-data -confdir $SNAP_DATA/config/core-data/res --registry
     command-chain:
       - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     environment:
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-core-data/secrets-token.json
     daemon: simple
@@ -236,6 +237,7 @@ apps:
     command: bin/core-metadata -confdir $SNAP_DATA/config/core-metadata/res --registry
     command-chain:
       - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     environment:
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-core-metadata/secrets-token.json
     daemon: simple
@@ -249,6 +251,7 @@ apps:
     command: bin/core-command -confdir $SNAP_DATA/config/core-command/res --registry
     command-chain:
       - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     environment:
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-core-command/secrets-token.json
     daemon: simple
@@ -262,6 +265,7 @@ apps:
     command: bin/support-notifications -confdir $SNAP_DATA/config/support-notifications/res --registry
     command-chain:
       - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     environment:
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-support-notifications/secrets-token.json
     daemon: simple
@@ -275,6 +279,7 @@ apps:
     command: bin/support-scheduler -confdir $SNAP_DATA/config/support-scheduler/res --registry
     command-chain:
       - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     environment:
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-support-scheduler/secrets-token.json
     daemon: simple
@@ -288,6 +293,7 @@ apps:
     command: bin/sys-mgmt-agent -confdir $SNAP_DATA/config/sys-mgmt-agent/res --registry
     command-chain:
       - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     environment:
       ExecutorPath: $SNAP/bin/sys-mgmt-agent-snap-executor.sh
     daemon: simple
@@ -300,6 +306,8 @@ apps:
       - core-data
       - core-metadata
     command: bin/device-virtual $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
+    command-chain:
+      - bin/service-config-overrides.sh
     daemon: simple
     environment:
       CONF_ARG: "--confdir=$SNAP_DATA/config/device-virtual"
@@ -313,6 +321,9 @@ apps:
       bin/app-service-configurable -cp -r -s
       -confdir $SNAP_DATA/config/app-service-configurable/res
       -profile rules-engine
+    command-chain:
+      - bin/security-secret-store-env-var.sh
+      - bin/service-config-overrides.sh
     daemon: simple
     environment:
       Binding_PublishTopic: events


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
This pull request adds rich config hook support, essentially creating config options which map 1x1 to per-service environment variable overrides.

## Issue Number:
NA

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

Environment variable overrides can now be enabled via config hook options. Overrides are specified as "env.<service>.<stanza>.<key>". Ex.

`$ sudo snap set edgexfoundry env.core-data.service.port=2112
`

The services currently supported are all the core-*, support-*, and SMA. The only stanza supported atm is [Service], and services must be restarted after one or more config options have changed.

**Note** - all of the configuration options below must be specified with the prefix:

`env.<service>
`

...where <service> is one of:

- core-command
- core-data
- core-metadata
- support-notifications
- support-scheduler
- sys-mgmt-agent

```
[Service]
service.boot-timeout                  // Service.BootTimeout
service.check-interval                // Service.CheckInterval
service.host                                   // Service.Host
service.server-bind-addr         // Service.ServerBindAddr
service.port                	             // Service.Port
service.protocol                          // Service.Protocol
service.max-result-count      // Service.MaxResultCount
service.startup-msg                 // Service.StartupMsg
service.timeout                          // Service.Timeout

[Registry]                                                                                                                                                 
registry.host           		// Registry.Host
registry.port            	 	// Registry.Port
registry.type            	 	// Registry.Type

[Clients.Command]                                                                                                                                     
clients.command.host            	// Clients.Command.Host
clients.command.port            	// Clients.Command.Port
clients.command.protocol         // Clients.Command.Protocol     

[Clients.Data]
clients.data.host               	// Clients.Data.Host
clients.data.port              	// Clients.Data.Port
clients.data.protocol            // Clients.Data.Protocol 
[Clients.Metadata]
clients.metadata.host           	// Clients.Metadata.Host
clients.metadata.port           	// Clients.Metadata.Port
clients.metadata.protocol        // Clients.Metadata.Protocol 

[Clients.Notifications]
clients.notifications.host       // Clients.Notifications.Host
clients.notifications.port       // Clients.Notifications.Port
clients.notifications.protocol   // Clients.Notifications.Protocol 

[Clients.Scheduler]
clients.scheduler.host           // Clients.Scheduler.Host
clients.scheduler.port           // Clients.Scheduler.Port
clients.scheduler.protocol       // Clients.Scheduler.Protocol 

[Databases]                                                                                                                                              
databases.primary.host		       // Databases.Primary.Host
databases.primary.name		       // Databases.Primary.Name
databases.primary.password		// Databases.Primary.Password                                                                                           
databases.primary.username		// Databases.Primary.Username                                                                                                 
databases.primary.port		       // Databases.Primary.Port
databases.primary.timeout		// Databases.Primary.Timeout
databases.primary.type		       // Databases.Primary.PrimaryType
[MessageQueue]                                                                                                                                                                                                                                                   
messagequeue.topic			       // MessageQueue.Topic

```
**Note** - as the snap doesn't yet support alternate message buses, `Topic` is the only `MessageQueue` configuration override allowed.

```
[SecretStore]                                                                                                                                            
secretstore.host                              // SecretStore.Host
secretstore.port                              // SecretStore.Port
secretstore.path                             // SecretStore.Path
secretstore.protocol			// SecretStore.Protocol
secretstore.root-ca-cert-path		        // SecretStore.RootCaCertPath
secretstore.server-name			        // SecretStore.ServerName
secretstore.token-file                                  // SecretStore.TokenFile
secretstore.additional-retry-attempts	// SecretStore.AdditionalRetryAttempts
secretstore.retry-wait-period		       // SecretStore.RetryWaitPeriod
[SecretStore.Authentication]                                                                                                    
secretstore.authentication.auth-type	// SecretStore.Authentication.AuthType
```

## Other information