### PR TITLE
feat(snap): add vault secret-token content interface

### DIFF
--- a/snap/hooks/connect-plug-edgex-secretstore-token
+++ b/snap/hooks/connect-plug-edgex-secretstore-token
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+APP_SVC_TOKEN="$SNAP_DATA/secrets/edgex-application-service/secrets-token.json"
+
+# Since this connection may happen *after* security-secretstore-setup
+# (and hence file-token-provider) has run, the token for app-service-cfg
+# probably has already been generated, meaning it won't appear in the
+# bind-mounted directory in app-service-cfg's slot directory.
+#
+# So, this script is a big hammer which deletes the token and then
+# restarts security-secretstore-setup to regenerate all the tokens,
+# which results in the token being accessible from the asc snap.
+logger "edgex-secretstore-token: $APP_SVC_TOKEN"
+rm -f "$APP_SVC_TOKEN"
+
+# Check for success of the rm operation as none of the standard
+# test options (-f, -e, -r, -w) seem to work properly to test
+# for existence of this file. This is probably due to permissions
+# of the parent directory, but should be first validated before
+# this comment is removed.
+#
+# Note - also tried was using 'rm <token>' and then checking the
+# status. This also fails because only 'rm -f' seems to work to
+# delete the file, and the status of the command is always 0,
+# even if the file doesn't exist!
+snapctl restart "$SNAP_NAME.security-secretstore-setup"
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,17 @@ passthrough:
         - snap/command-chain/snapcraft-runner
         - bin/snapcraft-preload
 
+plugs:
+  # This content interface provides a mechanism for the edgexfoundry
+  # snap to shared vault secret tokens in order for services in external
+  # edgex snap to access the secret-store. Note, in this case this snap
+  # defines a plug instead of slot to allow the consuming snap to create
+  # the service-specific directory under $SNAP_DATA/secrets.
+  edgex-secretstore-token:
+    interface: content
+    content: edgex-secretstore-token
+    target: $SNAP_DATA/secrets
+
 # kong runs things through luarocks and luarocks expects it's configuration to
 # be located here and we can't override this at runtime, so map what's in
 # $SNAP to the expected location


### PR DESCRIPTION
This content interface provides a mechanism for the edgexfoundry
snap to shared vault secret tokens in order for services in external
edgex snaps to access the secret-store. Note, in this case this snap
defines a plug instead of slot to allow the consuming snap to create
the service-specific directory under $SNAP_DATA/secrets.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
This PR adds a snap content interface used to share vault secret tokens with external application or device service snaps.

## Issue Number:
NA


## What is the new behavior?
If an external snap connects to the edgex-secret-store-token content interface, and the file-token-provider is configured to produce a token for the connecting snap, then the connecting snap will be able to access the secret token, and thus access the secret store (vault).

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Test instructions to be added shortly...

## Other information