### PR TITLE
feat(snap): additional configure hook features

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -68,6 +68,17 @@ conf_to_env["smtp.password"]="SMTP_PASSWORD"
 conf_to_env["smtp.port"]="SMTP_PORT"
 conf_to_env["smtp.sender"]="SMTP_SENDER"
 conf_to_env["smtp.enable-self-signed-cert"]="SMTP_ENABLE_SELF_SIGNED_CERT"
+#
+# security-proxy
+#
+# ADD_PROXY_ROUTE is a csv list of URLs to be added to the
+# API Gateway (aka Kong). For references:
+#
+# https://docs.edgexfoundry.org/1.3/microservices/security/Ch-APIGateway/
+#
+# TODO: validation
+#
+conf_to_env["add-proxy-route"]="ADD_PROXY_ROUTE"
 
 # The syntax to set a configuration key is:
 #
@@ -145,10 +156,22 @@ handle_config () {
 
     logger "edgex:configure: $map_init"
 
+    local service=$1
     local mapAsString
     mapAsString="$map_init"
     local -A "$mapAsString"
-    file="$SNAP_DATA/config/$1/res/$1.env"
+
+    # Handle security-* service naming. The service names in this
+    # hook historically do not align with the actual binary commands.
+    # As such, when handling configuration settings for them, we need
+    # to translate the hook name to the actual binary name.
+    #
+    # TODO: handle security-secret-store
+    if [ "$service" == "security-proxy" ]; then
+	service="security-proxy-setup"
+    fi
+
+    file="$SNAP_DATA/config/$service/res/$service.env"
 
     # if no $service.env file exists, create it
     # TODO: get rid of fore loop, and just access

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -79,6 +79,16 @@ conf_to_env["smtp.enable-self-signed-cert"]="SMTP_ENABLE_SELF_SIGNED_CERT"
 # TODO: validation
 #
 conf_to_env["add-proxy-route"]="ADD_PROXY_ROUTE"
+#
+# security-secret-store
+#
+# ADD_SECRETSTORE_TOKENS is a csv list of service keys to be added to the
+# list of Vault tokens that security-file-token-provider (launched by
+# security-secretstore-setup) creates.
+#
+# TODO: validation
+#
+conf_to_env["add-secretstore-tokens"]="ADD_SECRETSTORE_TOKENS"
 
 # The syntax to set a configuration key is:
 #
@@ -166,9 +176,10 @@ handle_config () {
     # As such, when handling configuration settings for them, we need
     # to translate the hook name to the actual binary name.
     #
-    # TODO: handle security-secret-store
     if [ "$service" == "security-proxy" ]; then
 	service="security-proxy-setup"
+    elif [ "$service" == "security-secret-store" ]; then
+	service="security-secretstore-setup"
     fi
 
     file="$SNAP_DATA/config/$service/res/$service.env"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -24,6 +24,11 @@ conf_to_env["registry.host"]="REGISTRY_HOST"
 conf_to_env["registry.port"]="REGISTRY_PORT"
 conf_to_env["registry.type"]="REGISTRY_TYPE"
 
+# [Clients.Coredata]
+conf_to_env["clients.coredata.host"]="CLIENTS_COREDATA_HOST"
+conf_to_env["clients.coredata.port"]="CLIENTS_COREDATA_PORT"
+conf_to_env["clients.coredata.protocol"]="CLIENTS_COREDATA_PROTOCOL"
+
 # [Clients.Metadata]
 conf_to_env["clients.metadata.host"]="CLIENTS_METADATA_HOST"
 conf_to_env["clients.metadata.port"]="CLIENTS_METADATA_PORT"
@@ -33,6 +38,7 @@ conf_to_env["clients.metadata.protocol"]="CLIENTS_METADATA_PROTOCOL"
 conf_to_env["clients.notifications.host"]="CLIENTS_METADATA_HOST"
 conf_to_env["clients.notifications.port"]="CLIENTS_METADATA_PORT"
 conf_to_env["clients.notifications.protocol"]="CLIENTS_METADATA_PROTOCOL"
+
 # [Databases]
 conf_to_env["databases.primary.host"]="DATABASES_PRIMARY_HOST"
 conf_to_env["databases.primary.name"]="DATABASES_PRIMARY_NAME"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,6 +173,7 @@ apps:
     plugs:
       - network
       - network-bind
+  # TODO: add support for env.overrides
   security-secretstore-setup:
     adapter: full
     after: [vault]
@@ -199,12 +200,15 @@ apps:
 
     start-timeout: 15m
     plugs: [network]
+  # TODO: add support for env.overrides
   security-proxy-setup:
     adapter: none
     after:
       - security-secretstore-setup
       - kong-daemon
     command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
+    command-chain:
+      - bin/service-config-overrides.sh
     environment:
       INIT_ARG: "--init=true"
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -179,6 +179,8 @@ apps:
     after: [vault]
     command: >-
       bin/security-secretstore-setup -confdir $SNAP_DATA/config/security-secretstore-setup/res $VAULT_INTERVAL
+    command-chain:
+      - bin/service-config-overrides.sh
     daemon: oneshot
     environment:
       VAULT_INTERVAL: "--vaultInterval=10"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
NA

## Issue Number:
NA

## What is the new behavior?
This PR adds the following new features to the configure hook:
  * support for configuring additional Kong routes
  * support for configuring additional Vault service tokens

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
### Kong Routes
For additional Kong routes, the new config option is `add-proxy-route`. It can be used to add one more more comma-separated services to the routes that Kong configures. For more details, please reference the [upstream documentation](https://docs.edgexfoundry.org/1.3/microservices/security/Ch-APIGateway/).

 Ex.

`$ sudo snap set edgexfoundry add-proxy-route="myApp.http://my-app:56789"
`

If the configuration is set from a gadget, the setting will take effect on the first start of security-proxy-setup, otherwise the service will need to be restarted in order for this setting to be picked up.

### Vault Tokens

For additional Vault tokens for services requiring Vault in external snaps, the new config option is `add-secretstore-tokens`. It can be used to add one more more comma-separated services to the routes that Kong configures.  

 Ex.

`$ sudo snap set edgexfoundry add-secretstore-tokens="myservice,yourservice,ourservice"
`

If the configuration is set from a gadget, the setting will take effect on the first start of security-secretstore-setup, otherwise the service will need to be restarted in order for this setting to be picked up.
