### PR TITLE
fix(snap): add install hook security config

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -142,6 +142,24 @@ if [ ! -f "$SNAP_DATA/config/security-proxy-setup/kong.conf" ]; then
     sed -i "s@#nginx_user = nobody nobody@nginx_user = root root@" "$SNAP_DATA/config/security-proxy-setup/kong.conf"
 fi
 
+# handle proxy and secret-store configuration
+#
+# TODO: this code needs to be merged with the configure
+# code once these hooks have been re-implemented in go.
+#
+# See configure hook for more details.
+#
+routes=$(snapctl get "env.security-proxy.add-proxy-route")
+tokens=$(snapctl get "env.security-secret-store.add-secretstore-tokens")
+
+if [ ! -z "$routes" ]; then
+    echo "export ADD_PROXY_ROUTE=$routes" > "$SNAP_DATA/config/security-proxy-setup/res/security-proxy-setup.env"
+fi
+
+if [ ! -z "$tokens" ]; then
+    echo "export ADD_SECRETSTORE_TOKENS=$tokens" > "$SNAP_DATA/config/security-secretstore-setup/res/security-secretstore-setup.env"
+fi
+
 # setup postgres db config file with env vars replaced
 if [ ! -f "$SNAP_DATA/etc/postgresql/10/main/postgresql.conf" ]; then
     mkdir -p "$SNAP_DATA/etc/postgresql/10/main"


### PR DESCRIPTION
This change allows the install hook to process
the security-proxy.add-proxy-route and security-
secretstore.add-secretstore-tokens config options.
Previously these options were only processed by
the configure hook.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information