### PR TITLE
fix(snap): restrict consul to localhost

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -125,7 +125,7 @@ Currently, the security services are enabled by default. The security services c
  * security-secretstore-setup
  * security-proxy-setup
 
-Vault is used for secret management, and Kong is used as an HTTPS proxy for all the services.
+Vault is used for secret management, and Kong is used as an HTTPS proxy for all the services (including Consul).
 
 Kong can be disabled by using the following command:
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -112,6 +112,16 @@ for key in $ALL_SERVICES; do
             # just ignore this request
             ;;
         security-proxy)
+            # TODO: this code will need to be re-factored when rich configure
+            # support is released for the edgexfoundry snap.
+            #
+            # NOTE - this logic always overrwrites the existing value. This
+            # should be fixed when rich config hook is implemented.
+            add_proxy_route=$(snapctl get env.security-proxy.add-proxy-route)
+            env_file="$SNAP_DATA/config/security-proxy-setup/res/security-proxy-setup.env"
+            logger "edgex:configure: writing ADD_PROXY_ROUTE=$add_proxy_routes to $envfile"
+            echo "export ADD_PROXY_ROUTE=$add_proxy_route" > "$env_file"
+
             # the security-proxy consists of the following base services
             # - kong
             # - postgres (because kong requires it)

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -131,6 +131,20 @@ if [ ! -f "$SNAP_DATA/config/security-secret-store/vault-config.hcl" ]; then
     chmod 644 "$SNAP_DATA/config/security-secret-store/vault-config.hcl"
 fi
 
+# If env.security-proxy.add-proxy-route is not explicitly set, initialize it
+# by adding consul
+add_proxy_route=$(snapctl get env.security-proxy.add-proxy-route)
+if [ -z "$add_proxy_route" ]; then
+    add_proxy_route="consul.http://localhost:8500"
+    snapctl set env.security-proxy.add-proxy-route="$add_proxy_route"
+fi
+
+# TODO: add validation of add_proxy_route
+
+env_file="$SNAP_DATA/config/security-proxy-setup/res/security-proxy-setup.env"
+logger "edgex:install: writing ADD_PROXY_ROUTE=$add_proxy_routes to $envfile"
+echo "export ADD_PROXY_ROUTE=$add_proxy_route" > "$env_file"
+
 # the kong config file needs to be generated with 3 changes from the default one included in the snap
 # - we set the prefix to be $SNAP_DATA/kong as an absolute path (note that this has to be done here in the install hook)
 # - we set the nginx user to be root

--- a/snap/local/runtime-helpers/bin/service-config-overrides.sh
+++ b/snap/local/runtime-helpers/bin/service-config-overrides.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# convert cmdline to string array
+ARGV=($@)
+
+# grab binary path
+BINPATH="${ARGV[0]}"
+logger "edgex service override: BINPATH=$BINPATH"
+
+# binary name == service name/key
+SERVICE=$(basename "$BINPATH")
+logger "edgex service override: SERVICE=$SERVICE"
+
+SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+logger "edgex service override: : SERVICE_ENV=$SERVICE_ENV"
+
+if [ -f "$SERVICE_ENV" ]; then
+    logger "edgex service override: : sourcing $SERVICE_ENV"
+    source "$SERVICE_ENV"
+fi
+
+exec "$@"

--- a/snap/local/runtime-helpers/bin/start-consul.sh
+++ b/snap/local/runtime-helpers/bin/start-consul.sh
@@ -4,7 +4,7 @@
 "$SNAP/bin/consul" agent \
     -data-dir="$SNAP_DATA/consul/data" \
     -config-dir="$SNAP_DATA/consul/config" \
-    -server -client=0.0.0.0 -bind=127.0.0.1 -bootstrap -ui &
+    -server -bind=127.0.0.1 -bootstrap -ui &
 
 # loop trying to connect to consul, as soon as we are successful exit
 # NOTE: ideally consul would be able to notify systemd directly, but currently 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,6 +191,8 @@ apps:
       - security-secretstore-setup
       - kong-daemon
     command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
+    command-chain:
+      - bin/service-config-overrides.sh
     environment:
       INIT_ARG: "--init=true"
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json


### PR DESCRIPTION
This commit updates the consul startup script to
no longer specify a client IPv4 address, which
causes consul to default to localhost, effectively
preventing consul access from another system. This
change also adds support for the a new config option:

env.security-proxy.add-proxy-route

...which can be used to add additional services to
the API Gateway. If add-proxy-route is not configured
prior to snap install, it will be initialized at install
time to:

consul.http://localhost:8500

This causes a proxy route to be setup for Consul along
with all of the default services.

## What is the current behavior?
Consul's REST API is configured to listen on all network interfaces.

## What is the new behavior?
Consul's REST API is updated to only listen on localhost. Additionally a route is automatically added to the API Gateway for Consul.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Testing Instructions
- [ ] Verify that consul's kv API can be reached from an external system using the edgexfoundry snap (amd64) from `latest/stable` (2809):

```
$ curl http://<ip address>:8500/v1/kv/edgex/core/1.0/edgex-core-data/Service/Port?raw
48080
```

 - Next install the snap built from this PR
 - [ ] verify that `snap get edgexfoundry env.security-proxy.add-proxy-route` returns the string `consul.http://localhost:8500`.
 - [ ] verify that the file `$SNAP_DATA/config/security-proxy-setup/res/security-proxy-setup.env `exists and contains the string:

`export ADD_PROXY_ROUTE=consul.http://localhost:8500`


 - [ ] verify that Consul's REST API is not reachable from an external system:


```
$ curl http://<ip address>:8500/v1/kv/edgex/core/1.0/edgex-core-data/Service/Port?raw
curl: (7) Failed to connect to <ip address>10.211.55.5 port 8500: Connection refused
```


 - [ ] verify that the API could be reached with a proper API Gateway (aka Kong) access token

```
$ cd /var/snap/edgexfoundry/current/config/security-proxy-setup/
$ sudo edgexfoundry.security-proxy-setup-cmd --init=false --useradd=ozzy --group=admin
```

 - grab the token from the output (looks like a long hex string with three components separated by "."s (ex. `eyJhbVCJ9.eyJpc3Mi.OiJEdjZH`)
 
 - then issue curl commands to kong's proxy endpoint like so:

 - [ ] access core-data's ping:

`$ curl -k https://localhost:8443/coredata/api/v1/ping --header "Authorization: Bearer <YOUR-TOKEN>"`

**Note**: -k turns off all certificate check and is useful for testing.

 - [ ] access consul kv:

```
curl -k https://localhost:8443/consul/v1/kv/edgex/core/1.0/edgex-core-data/Service/Port?raw --header "Authorization: Bearer <YOUR-TOKEN>"
48080
```

 - [ ] now verify that this also works from an external machine:

```
$ curl -k https://<EdgeX IP address>:8443/consul/v1/kv/edgex/core/1.0/edgex-core-data/Service/Port?raw --header "Authorization: Bearer <YOUR-TOKEN>"
48080
```

For additional details please refer to the EdgeX documentation for the API Gateway:

https://docs.edgexfoundry.org/1.3/microservices/security/Ch-APIGateway/
