### PR TITLE
Disable Vault TLS and add Vault secret-token content interface

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -44,6 +44,7 @@ WhiteList = "admin"
 
 [SecretService]
 Server = "localhost"
+Scheme = "https"
 Port = 8200
 HealthCheckPath = "v1/sys/health"
 CertPath = "/v1/secret/edgex/edgex-security-proxy-setup/"

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -76,6 +76,7 @@ type KongAclInfo struct {
 }
 
 type SecretServiceInfo struct {
+	Scheme          string
 	Server          string
 	Port            int
 	HealthcheckPath string
@@ -130,11 +131,18 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	//To keep config file for proxy unchanged in Geneva we need to create a temporary SecretStore struct so that bootstrapHandler can use it to create a secret client
 	//The config file may be changed in the future version and SecretStore can be used directly like other core services
+
+	// Note - see issue #2873 for details on why this default value is set here
+	scheme := c.SecretService.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+
 	ss := bootstrapConfig.SecretStoreInfo{
 		Host:                    c.SecretService.Server,
 		Port:                    c.SecretService.Port,
 		Path:                    c.SecretService.CertPath,
-		Protocol:                "https",
+		Protocol:                scheme,
 		RootCaCertPath:          c.SecretService.CACertPath,
 		ServerName:              c.SecretService.Server,
 		Authentication:          vault.AuthenticationInfo{AuthType: "X-Vault-Token"},

--- a/snap/hooks/connect-plug-edgex-secretstore-token
+++ b/snap/hooks/connect-plug-edgex-secretstore-token
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+APP_SVC_TOKEN="$SNAP_DATA/secrets/edgex-application-service/secrets-token.json"
+
+# Since this connection may happen *after* security-secretstore-setup
+# (and hence file-token-provider) has run, the token for app-service-cfg
+# probably has already been generated, meaning it won't appear in the
+# bind-mounted directory in app-service-cfg's slot directory.
+#
+# So, this script is a big hammer which deletes the token and then
+# restarts security-secretstore-setup to regenerate all the tokens,
+# which results in the token being accessible from the asc snap.
+logger "edgex-secretstore-token: $APP_SVC_TOKEN"
+rm -f "$APP_SVC_TOKEN"
+
+# Check for success of the rm operation as none of the standard
+# test options (-f, -e, -r, -w) seem to work properly to test
+# for existence of this file. This is probably due to permissions
+# of the parent directory, but should be first validated before
+# this comment is removed.
+#
+# Note - also tried was using 'rm <token>' and then checking the
+# status. This also fails because only 'rm -f' seems to work to
+# delete the file, and the status of the command is always 0,
+# even if the file doesn't exist!
+snapctl restart "$SNAP_NAME.security-secretstore-setup"
+

--- a/snap/local/runtime-helpers/config/security-secret-store/vault-config.hcl.in
+++ b/snap/local/runtime-helpers/config/security-secret-store/vault-config.hcl.in
@@ -9,7 +9,7 @@
 
 listener "tcp" { 
   address = "localhost:8200" 
-  tls_disable = "0" 
+  tls_disable = "1"
   cluster_address = "localhost:8201"
   tls_min_version = "tls12"
   tls_client_ca_file ="$SNAP_DATA/secrets/ca/ca.pem"
@@ -21,8 +21,8 @@ backend "consul" {
   path = "vault/"
   address = "localhost:8500"
   scheme = "http"
-  redirect_addr = "https://localhost:8200"
-  cluster_addr = "https://localhost:8201"
+  redirect_addr = "http://localhost:8200"
+  cluster_addr = "http://localhost:8201"
 }
 
 default_lease_ttl = "168h"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,7 +147,7 @@ apps:
     daemon: simple
     environment:
       VAULT_CONFIG: "$SNAP_DATA/config/security-secret-store/vault-config.hcl"
-      VAULT_ADDR: "https://localhost:8200"
+      VAULT_ADDR: "http://localhost:8200"
     plugs:
       - network
       - network-bind
@@ -156,7 +156,7 @@ apps:
     command: bin/vault
     environment:
       VAULT_CONFIG: "$SNAP_DATA/config/security-secret-store/vault-config.hcl"
-      VAULT_ADDR: "https://localhost:8200"
+      VAULT_ADDR: "http://localhost:8200"
     plugs:
       - network
       - network-bind
@@ -177,6 +177,7 @@ apps:
       SecretService_TokenProvider: $SNAP/bin/security-file-token-provider
       SecretService_TokenProviderArgs: "-confdir, $SNAP_DATA/config/security-file-token-provider/res"
       SecretService_TokenProviderAdminTokenPath: $SNAP_DATA/secrets/tokenprovider/secrets-token.json
+      SecretService_Scheme: http
 
       # environment for security-file-token-provider, exec'd by secretstore-setup
       TokenFileProvider_PrivilegedTokenPath: $SNAP_DATA/secrets/tokenprovider/secrets-token.json
@@ -197,6 +198,7 @@ apps:
       INIT_ARG: "--init=true"
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
       SecretService_CACertPath: $SNAP_DATA/secrets/ca/ca.pem
+      SecretService_Scheme: http
     daemon: oneshot
     start-timeout: 15m
     plugs: [network]
@@ -214,6 +216,7 @@ apps:
       SecretStore_ServerName: localhost
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-security-bootstrap-redis/secrets-token.json
       SecretStore_RooCaCertPath: $SNAP_DATA/secrets/ca/ca.pem
+      SecretStore_Protocol: http
     daemon: oneshot
     plugs: [network]
   core-data:
@@ -225,6 +228,7 @@ apps:
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
+      SecretStore_Protocol: http
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-core-data/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]
@@ -241,6 +245,7 @@ apps:
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
+      SecretStore_Protocol: http
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-core-metadata/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]
@@ -254,6 +259,7 @@ apps:
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
+      SecretStore_Protocol: http
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-core-command/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]
@@ -267,6 +273,7 @@ apps:
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
+      SecretStore_Protocol: http
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-support-notifications/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]
@@ -280,6 +287,7 @@ apps:
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
+      SecretStore_Protocol: http
       SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-support-scheduler/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,17 @@ passthrough:
         - snap/command-chain/snapcraft-runner
         - bin/snapcraft-preload
 
+plugs:
+  # This content interface provides a mechanism for the edgexfoundry
+  # snap to shared vault secret tokens in order for services in external
+  # edgex snap to access the secret-store. Note, in this case this snap
+  # defines a plug instead of slot to allow the consuming snap to create
+  # the service-specific directory under $SNAP_DATA/secrets.
+  edgex-secretstore-token:
+    interface: content
+    content: edgex-secretstore-token
+    target: $SNAP_DATA/secrets
+
 # kong runs things through luarocks and luarocks expects it's configuration to
 # be located here and we can't override this at runtime, so map what's in
 # $SNAP to the expected location

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,6 +72,10 @@ grade: stable
 confinement: strict
 
 # This applies to all apps
+# Even though Vault TLS is now disabled, this is still needed,
+# otherwise the secret-client will fail trying to read the
+# default CA defined in the various service configuration.toml
+# files. This should be possible to remove for Ireland.
 environment:
   SecretStore_RootCaCertPath: $SNAP_DATA/secrets/ca/ca.pem
 apps:


### PR DESCRIPTION
This PR contains commits from two previous PRs made to the hanoi-b1-lp branch:

1) From https://github.com/canonical/edgex-go/pull/7 Disable vault tls
This PR disables Vault TLS usage in the snap.

953f21d000db2f87c19a20274138127e0b26d8fb fix(security): fix proxy vault configuration
83d6eb13714566b61955b80db84fe4bea08ea1f1 feat(snap): disable secret-store (vault) TLS

2) From https://github.com/canonical/edgex-go/pull/8 feat(snap): add vault secret-token content interface
This content interface provides a mechanism for the edgexfoundry
snap to shared vault secret tokens in order for services in external
edgex snaps to access the secret-store. Note, in this case this snap
defines a plug instead of slot to allow the consuming snap to create
the service-specific directory under $SNAP_DATA/secrets.

61472b8a1de51060e38645eb66e518d3a0b07214 feat(snap): add vault secret-token content interface




## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

1. This PR disables Vault TLS usage in the snap.
2. This PR adds a snap content interface used to share vault secret tokens with external application or device service snaps.

## Issue Number:


## What is the new behavior?
1. HTTP is used by core-, security-, support-*, and app-service-configurable when communicating with Vault.
2. If an external snap connects to the edgex-secret-store-token content interface, and the file-token-provider is configured to produce a token for the connecting snap, then the connecting snap will be able to access the secret token, and thus access the secret store (vault).

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
To test, install the snap and ensure that all of the expected services are active and do not produce any error log messages. Validating data from from device-virtual would also be a good test case.

