### PR TITLE
security-proxy-setup-cmd updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -350,6 +350,7 @@ apps:
     adapter: none
     command: bin/security-proxy-setup
     environment:
+      KongAuth_OutputPath: $SNAP_DATA/access_token.json
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
       SecretService_CACertPath: $SNAP_DATA/secrets/ca/ca.pem
     plugs: [home, removable-media, network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -353,6 +353,7 @@ apps:
       KongAuth_OutputPath: $SNAP_DATA/access_token.json
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
       SecretService_CACertPath: $SNAP_DATA/secrets/ca/ca.pem
+      SecretService_Scheme: http
     plugs: [home, removable-media, network]
   redis-cli:
     adapter: full

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -348,7 +348,7 @@ apps:
   # helper commands the snap exposes
   security-proxy-setup-cmd:
     adapter: none
-    command: bin/security-proxy-setup
+    command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res
     environment:
       KongAuth_OutputPath: $SNAP_DATA/access_token.json
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json


### PR DESCRIPTION
This PR contains three changes to security-proxy-setup-cmd:

1. Set the location of the access token, output by security-proxy-setup-cmd, to $SNAP_DATA (/var/snap/edgexfoundry/current), instead of using the current working directory
2. Run security-proxy-setup-cmd with '-confdir /var/snap/edgexfoundry/current/config/security-proxy-setup/res', so that the setting does not need to be specified by the user. Adding a new user can therefore be done simply with

```
sudo edgexfoundry.security-proxy-setup-cmd --useradd=me --group=admin
```
3. As TLS has been disabled for Vault, set the scheme of the secret service to 'http' for the security-proxy-setup-cmd command

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information