### PR TITLE
Update kong part

### DIFF
--- a/snap/local/runtime-helpers/bin/service-config-overrides.sh
+++ b/snap/local/runtime-helpers/bin/service-config-overrides.sh
@@ -5,15 +5,10 @@ ARGV=($@)
 
 # grab binary path
 BINPATH="${ARGV[0]}"
-logger "edgex service override: BINPATH=$BINPATH"
 
 # binary name == service name/key
 SERVICE=$(basename "$BINPATH")
-logger "edgex service override: SERVICE=$SERVICE"
-
 SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
-
-logger "edgex service override: : SERVICE_ENV=$SERVICE_ENV"
 
 if [ -f "$SERVICE_ENV" ]; then
     logger "edgex service override: : sourcing $SERVICE_ENV"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -724,16 +724,16 @@ parts:
       # note - we specifically don't use arch
       case "$(dpkg --print-architecture)" in
         amd64)
-          FILE_NAME=kong-2.0.5.xenial.amd64.deb
+          FILE_NAME=kong_2.0.5_amd64.deb
           FILE_HASH=450223a011dba0d6eeb6a192be368e7bcd45a5dc063c743ed6f3d37eb95237b8
           ;;
         arm64)
-          FILE_NAME=kong-2.0.5.xenial.arm64.deb
+          FILE_NAME=kong_2.0.5_arm64.deb
           FILE_HASH=15aa5fb2eb0c992afa277b09cb03b3b940df9704ab9e8d93327a72c0cb87eb09
           ;;
       esac
       # download the archive, failing on ssl cert problems
-      curl -L https://bintray.com/kong/kong-deb/download_file?file_path=$FILE_NAME -o $FILE_NAME
+      curl -L https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/$FILE_NAME -o $FILE_NAME
       echo "$FILE_HASH $FILE_NAME" > sha256
       sha256sum -c sha256 | grep OK
       dpkg -x $FILE_NAME $SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
This PR updates the kong part in the snap to use the new Kong download site, as bintry.com has been deprecated. It also includes one other minor change to the service env override wrapper script to get rid of some leftover debug logging.