### PR TITLE
fix(snap): fix install problem with connect hook

### DIFF
--- a/snap/hooks/connect-plug-edgex-secretstore-token
+++ b/snap/hooks/connect-plug-edgex-secretstore-token
@@ -2,14 +2,33 @@
 
 APP_SVC_TOKEN="$SNAP_DATA/secrets/edgex-application-service/secrets-token.json"
 
-# Since this connection may happen *after* security-secretstore-setup
-# (and hence file-token-provider) has run, the token for app-service-cfg
-# probably has already been generated, meaning it won't appear in the
-# bind-mounted directory in app-service-cfg's slot directory.
+# This connection can happen before or after security-secretstore-setup
+# (a oneshot service that configures Vault) has already run. The first
+# case happens when the content interface is auto-connected and the
+# edgex-app-service-configurable snap is installed before the edgexfoundry
+# snap. In this case there's action required.
+#
+# The latter happens when the order is swapped *and* the connection
+# is manually connected. In this case since security-secretstore-setup
+# (which runs file-token-provider) has already run, the token for
+# app-service-cfg will have already been generated, and thus be hidden
+# when the content interface directory from the app-service-configurable
+# snap is bind mounted on top of the existing /secrets directory.
 #
 # So, this script is a big hammer which deletes the token and then
 # restarts security-secretstore-setup to regenerate all the tokens,
 # which results in the token being accessible from the asc snap.
+#
+# NOTE - one final comment, app-service-configurable is included in the
+# edgexfoundry snap to provide for Kuiper integration. It's disabled by
+# default, and is hard-code to use the 'rules-engine' profile. Due to
+# the way vault tokens work, both the internal app-service-configurable
+# instance, and the instance in the app-service-configurable snap are
+# able to share the same token.
+if [ ! -f $APP_SVC_TOKEN" ]; then
+    exit 0
+fi
+
 logger "edgex-secretstore-token: $APP_SVC_TOKEN"
 rm -f "$APP_SVC_TOKEN"
 


### PR DESCRIPTION
This change fixes a problem with the vault content
interace connect hook which prevents the edgexfoundry
snap from being installed if the edgex-app-service-
configurable snap is installed first. See the comments
in the connect hook itself for more details.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
If edgex-app-service-configurable (from beta) is installed first, then the edgexfoundry snap cannot be installed, as it fails in the connect hook used to regenerate vault token (i.e. by restarting security-secretstore-setup).

## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ x] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

Steps to reproduce:

1) Install edgex-app-service-configurable (--beta)
2) Install edgexfoundry (--beta)

Replace the snap in step (2) with one built from this PR, and everything works as expected.


## Other information