### PR TITLE
fix(snap): resolve kong errors with stopping kong & install config paths

### DIFF
--- a/hooks/cmd/install/install.go
+++ b/hooks/cmd/install/install.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks"
 )
@@ -232,8 +233,11 @@ func installProxy() error {
 		return err
 	}
 
+	// ensure prefix uses the 'current' symlink in it's path, otherwise refreshes to a
+	// new snap revision will break
+	snapDataCurr := strings.Replace(hooks.SnapData, hooks.SnapRev, "current", 1)
 	rStrings := map[string]string{
-		"#prefix = /usr/local/kong/":  "prefix = " + hooks.SnapData + "/kong",
+		"#prefix = /usr/local/kong/":  "prefix = " + snapDataCurr + "/kong",
 		"#nginx_user = nobody nobody": "nginx_user = root root",
 	}
 

--- a/snap/local/runtime-helpers/bin/kong-stop.sh
+++ b/snap/local/runtime-helpers/bin/kong-stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # stop kong
-"$SNAP/bin/kong" stop -p "$SNAP_DATA/kong"
+"$SNAP/usr/local/bin/kong" stop -p "$SNAP_DATA/kong"
 
 # in some cases stopping kong doesn't succeed properly, so to ensure that
 # it always is put into a state where it can startup, just remove the env


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [ NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
There are two issues related to Kong:
  - the stop script is broken because it uses `/bin/kong` instead `/usr/local/bin/kong`
  - the install hook doesn't properly update the kong.conf file to use the 'current' symlink version of `$SNAP_DATA`

This latter problem caused the test-install-config-paths checkbox test fail. It also prevents a refresh from the last revision published to beta to this revision.

## Issue Number:
NA

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information