### PR TITLE
fix(snap): fix quoting error in connect hook

### DIFF
--- a/snap/hooks/connect-plug-edgex-secretstore-token
+++ b/snap/hooks/connect-plug-edgex-secretstore-token
@@ -25,7 +25,7 @@ APP_SVC_TOKEN="$SNAP_DATA/secrets/edgex-application-service/secrets-token.json"
 # the way vault tokens work, both the internal app-service-configurable
 # instance, and the instance in the app-service-configurable snap are
 # able to share the same token.
-if [ ! -f $APP_SVC_TOKEN" ]; then
+if [ ! -f "$APP_SVC_TOKEN" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information

To test, properly this PR needs to land, so that this snap is installed from the store.

Next install the beta version of edgex-app-service-configurable. Without this fix, the edgexfoundry connect hook will fail, causing the edgex-app-service-configurable snap install to fail...

Note - without this change, shellcheck also fails on this hook, so we should ensure that we always run shellcheck on future changes and/or new shell scripts that get added.