### PR TITLE
fix(snap): add edgex-secretstore-token prepare hook

### DIFF
--- a/snap/hooks/prepare-plug-edgex-secretstore-token
+++ b/snap/hooks/prepare-plug-edgex-secretstore-token
@@ -1,35 +1,33 @@
 #!/bin/bash
 
-APP_SVC_TOKEN=/tmp/asc-secrets-token.json
-TARGET_PATH="$SNAP_DATA/secrets/edgex-application-service/secrets-token.json"
+APP_SVC_TOKEN="$SNAP_DATA/secrets/edgex-application-service/secrets-token.json"
+TARGET_PATH=/tmp/asc-secrets-token.json
 
 # This connection can happen before or after security-secretstore-setup
 # (a oneshot service that configures Vault) has already run. The first
 # case happens when the content interface is auto-connected and the
 # edgex-app-service-configurable snap is installed before the edgexfoundry
-# snap.
+# snap. In this case there's no action required as security-secretstore-
+# -setup will write it's token to the source dir which has been bind
+# mounted over the dir of the same name in this snap.
 #
 # The latter happens when the order is swapped *and* the connection
 # is manually connected. In this case since security-secretstore-setup
 # (which runs file-token-provider) has already run, the token for
-# app-service-cfg will have already been generated, and thus will be
-# hidden when the content interface directory from the
-# app-service-configurable snap is bind mounted on top of the existing
-# /secrets directory.
+# app-service-cfg will have already been generated, and thus be hidden
+# when the content interface directory from the app-service-configurable
+# snap is bind mounted on top of the existing /secrets directory.
 #
-# The corresponding prepare hook (which runs before the bind mount) for
-# this content interface is used to copy the token to /tmp.
-#
-# This script checks for the token in /tmp, and if found, moves it to
-# the new bind mounted directory.
+# Since this hook is called before the bind mount has happened, it checks
+# to see if the file exists, and if so, copies it to  /tmp.
 #
 # NOTE - one final comment, app-service-configurable is included in the
 # edgexfoundry snap to provide for Kuiper integration. It's disabled by
-# default, and is hard-code to use the 'rules-engine' profile. Due to
+# default, and is hard-coded to use the 'rules-engine' profile. Due to
 # the way vault tokens work, both the internal app-service-configurable
 # instance, and the instance in the app-service-configurable snap are
 # able to share the same token.
 if [ -f "$APP_SVC_TOKEN" ]; then
-    logger "edgex-secretstore-token: $APP_SVC_TOKEN copied to $TARGET_PATH"
+    logger "edgex-secretstore-token: token found in $APP_SVC_TOKEN; moving to $TARGET_PATH"
     mv "$APP_SVC_TOKEN" "$TARGET_PATH"
 fi


### PR DESCRIPTION
This change adds a prepare hook for the edgex-secretstore-token
content interface. This script moves token (if found) to
/tmp. The corresponding connect hook moves the token back into
place after the content interface bind mount has occurred.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information