### PR TITLE
fix(snap): disable Vault TLS in post-refresh hook

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+# disable Vault TLS
+cp $SNAP/config/security-secret-store/vault-config.hcl $SNAP_DATA/config/security-secret-store/
+ 


### PR DESCRIPTION
EdgeX assumes Vault doesn't use TLS. It is disabled in a Vault config file
installed in the install hook. When refreshing from an earlier version
of EdgeX, we may have an invalid config file with TLS enabled.

This update therefore uses the post-refresh hook to update the
Vault configuration file.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information