### PR TITLE
snap: add generic app service store tokens

### DIFF
--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -35,7 +35,8 @@ const consulAddRegistryACLRolesCfg = "env.security-bootstrapper.add-registry-acl
 
 // device-rest and device-virtual are both on the /cmd/security-file-token-provider/res/token-config.json file,
 // so they should not need to be set here as well
-const secretStoreTokens = "app-http-export,app-mqtt-export,device-camera,device-mqtt,device-modbus,device-coap,device-snmp"
+const secretStoreTokens = "app-http-export,app-mqtt-export,device-camera,device-mqtt,device-modbus,device-coap,device-snmp," +
+                           "application-service,app-hackathon"
 
 const secretStoreKnownSecrets = "" +
 	"redisdb[app-rules-engine]," +


### PR DESCRIPTION
This PR updates the snap install hook to specify two
additional secret store tokens:

 - application-service
 - app-hackathon

The first is the same as EdgeX 1.x, where a single
token was generated which could be used by any app
service using the service name 'application-service'.
In Ireland, the only default app service tokens created
by default map to the pre-defined app-service-configurable
profiles (e.g. 'app-http-export', 'app-mqtt-export').

The second token is a generic name that can leveraged by
participants in the 2021 EdgeX Hackathon.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

